### PR TITLE
리팩토링 진행

### DIFF
--- a/apps/sample/src/pages/DesignSystem.tsx
+++ b/apps/sample/src/pages/DesignSystem.tsx
@@ -122,7 +122,7 @@ function DesignSystem() {
       <h2 className="text-xl font-bold mt-8 mb-4">Badge 컴포넌트 예제</h2>
       <Badge>뱃지</Badge>
       <h2 className="text-xl font-bold mt-8 mb-4">Checkbox 컴포넌트 예제</h2>
-      <Checkbox label="체크박스" variant="primary" type="circle" disabled/>
+      <Checkbox label="체크박스" color="primary" type="circle" disabled/>
       <h2 className="text-xl font-bold mt-8 mb-4">Skeleton 컴포넌트 예제</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Skeleton variant="circle" className="w-[180px] h-[180px]"></Skeleton>

--- a/packages/ui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.stories.tsx
@@ -1,10 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Accordion } from '../Accordion';
 
-Accordion.Item.displayName = 'Accordion.Item';
-Accordion.Trigger.displayName = 'Accordion.Trigger';
-Accordion.Content.displayName = 'Accordion.Content';
-
 const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion',
   component: Accordion,

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { useState, useRef, useEffect } from "react";
-import { v4 as uuidv4 } from "uuid";
+import { useState, useRef, useEffect, useId } from "react";
 import { cn } from '../../utils/classname';
 import AccordionIcon from '../../assets/icons/Accordion.svg';
 import type { 
@@ -11,15 +10,14 @@ import type {
 } from './Accordion.types';
 
 
-const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
-({ 
+const Accordion = React.memo(({ 
   type = "single",
   collapsible = false,
   onChange,
   className, 
   children,
   ...props 
-}, ref) => {
+}: AccordionProps) => {
   
     const [accordionState, setAccordionState] = useState<Set<string>>(new Set());
 
@@ -64,49 +62,46 @@ const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
 
     return (
         <div
-        ref={ref}
-        className={cn("flex flex-col bg-gray-100", className)}
-        {...props}
-        >
-        {elementProps}
+          className={cn("flex flex-col bg-gray-100", className)}
+          {...props}
+          >
+          {elementProps}
         </div>
     );
 });
 
 Accordion.displayName = 'Accordion';
 
-const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
-({ 
+const AccordionItem = React.memo(({ 
   disabled = false,
   isOpen = false, 
   onToggle,
   className,  
   children,
   ...props 
-}, ref) => {
-
-  const uniqueIdRef = useRef(uuidv4());
-  const buttonId = `button-${uniqueIdRef.current}`;
-  const contentId = `content-${uniqueIdRef.current}`;
+}: AccordionItemProps) => {
+  const uniqueId = useId();
+  const buttonId = `button-${uniqueId}`;
+  const contentId = `content-${uniqueId}`;
 
   const elementProps = React.Children.map(children, child => {
     if(React.isValidElement(child)){
-        if((child.type as AccordionTriggerProps) === AccordionTrigger){
-          return React.cloneElement(child, {
-            isOpen,
-            disabled,
-            id: buttonId,
-            "aria-controls": contentId,
-            onToggle,
-          } as AccordionTriggerProps);
+        if(child.type === AccordionTrigger){
+            return React.cloneElement(child, {
+                isOpen,
+                disabled,
+                id: buttonId,
+                "aria-controls": contentId,
+                onToggle,
+            } as AccordionTriggerProps);
         }
 
-        if((child.type as AccordionContentProps) === AccordionContent){
-          return React.cloneElement(child,{
-            isOpen,
-            id: contentId,
-            "aria-labelledby": buttonId,
-          } as AccordionContentProps);
+        if(child.type === AccordionContent){
+            return React.cloneElement(child, {
+                isOpen,
+                id: contentId,
+                "aria-labelledby": buttonId,
+            } as AccordionContentProps);
         }
     }
     return child;
@@ -114,7 +109,6 @@ const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
 
   return (
     <div
-      ref={ref}
       className={cn(
         "border-b border-gray-300", 
         disabled && "opacity-50 cursor-not-allowed",
@@ -129,15 +123,15 @@ const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
 
 AccordionItem.displayName = 'AccordionItem';
 
-const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTriggerProps>(
-({ 
+const AccordionTrigger = React.memo(({ 
   isOpen = false,
   disabled = false,
   onToggle,
   className, 
   children, 
+  ref,
   ...props 
-}, ref) => {
+}: AccordionTriggerProps) => {
  
   return (
     <button
@@ -169,13 +163,13 @@ const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTriggerPro
 AccordionTrigger.displayName = "AccordionTrigger";
 
 
-const AccordionContent = React.forwardRef<HTMLDivElement, AccordionContentProps>(
-  ({ 
+const AccordionContent = React.memo(({ 
     isOpen = false,
     className, 
     children, 
+    ref,
     ...props 
-  }, ref) => {
+  }: AccordionContentProps) => {
     
     const contentRef = useRef<HTMLDivElement>(null);
     const [contentHeight, setContentHeight] = useState<number>(0);

--- a/packages/ui/src/components/Accordion/Accordion.types.ts
+++ b/packages/ui/src/components/Accordion/Accordion.types.ts
@@ -1,33 +1,27 @@
-import { HTMLAttributes } from 'react';
-import * as React from 'react';
-
-export interface AccordionProps {
+export interface AccordionProps{
     type?: "single" | "multiple";
     collapsible?: boolean;
     onChange?: (value: string) => void;
-    className?: string;
+    className?: string
     children?: React.ReactNode;
 }
 
-export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+export interface AccordionItemProps extends React.ComponentProps<'div'>{
     value: string;
     disabled?: boolean;
     isOpen?: boolean; 
     onToggle?: () => void;
-    className?: string;
     children?: React.ReactNode;
 }
 
-export interface AccordionTriggerProps extends HTMLAttributes<HTMLButtonElement> {
+export interface AccordionTriggerProps extends React.ComponentProps<'button'> {
     isOpen?: boolean;
     disabled?: boolean;
     onToggle?: () => void; 
-    className?: string;
     children?: React.ReactNode;
 }
 
-export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {
+export interface AccordionContentProps extends React.ComponentProps<'div'> {
     isOpen?: boolean; 
-    className?: string;
     children?: React.ReactNode;
 } 

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,19 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Badge from './Badge';
+import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
     title: 'Components/Badge',
     component: Badge,
     tags: ['autodocs'],
     argTypes : {
-        variant: {
+        color: {
             control : 'select',
-            options : ['primary', 'destructive'],
+            options : ['primary', 'secondary' ,'destructive'],
         },
         size: {
             control : 'select',
             options : ['xsmall', 'small', 'medium', 'large'],
-        }
+        },
+        className: {
+          control : 'text'
+        },
     }   
 };
 
@@ -23,20 +26,46 @@ type Story = StoryObj<typeof Badge>
 
 export const Primary: Story = {
     args: {
-      variant: 'primary',
+      color: 'primary',
       size:'xsmall',
       children: 'message',
       label: 'badge'
     },
   };
 
-  export const Destructive: Story = {
+export const Destructive: Story = {
     args: {
-      variant: 'destructive',
-      size:'xsmall',
+      color: 'destructive',
+      size: 'xsmall',
       children: 'notice',
       label: 'badge'
     },
   };
-  
 
+export const Colors: Story = {
+  render: () => (
+      <>
+        <div className="mt-4">Primary:</div>
+        <Badge color="primary" size="medium">Primary Badge</Badge>
+        <div className="mt-4">Secondary:</div>
+        <Badge color="secondary" size="medium">Secondary Badge</Badge>
+        <div className="mt-4">Destructive:</div>
+        <Badge color="destructive" size="medium">Destructive Badge</Badge>
+      </>
+    )
+};
+
+export const Sizes: Story = {
+    render: () => (
+      <>
+        <div className="mt-4">XSmall:</div>
+        <Badge color="primary" size="xsmall">XSmall Badge</Badge>
+        <div className="mt-4">Small:</div>
+        <Badge color="primary" size="small">Small Badge</Badge>
+        <div className="mt-4">Medium:</div>
+        <Badge color="primary" size="medium">Medium Badge</Badge>
+        <div className="mt-4">Large:</div>
+        <Badge color="primary" size="large">Large Badge</Badge>
+      </>
+    )
+};

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,15 +1,8 @@
-import {HTMLAttributes} from 'react';
 import {cn} from '../../utils/classname';
-
-export interface BadgeProps extends HTMLAttributes<HTMLSpanElement>{
-    variant?: 'primary' | 'destructive';
-    size?: 'xsmall' | 'small' | 'medium' | 'large';
-    className?: string;   
-    label?: string;
-}
+import type { BadgeProps } from './Badge.types';
 
 const Badge = ({
-    variant = 'primary',
+    color = 'primary',
     size = 'small',
     className,
     children,
@@ -19,10 +12,11 @@ const Badge = ({
 
     const badgeStyle = 'inline-flex justify-center items-center font-extrabold box-border rounded-full';
     
-    const variantStyle = {
+    const colorStyle = {
         primary : 'bg-primary-500 text-white',
+        secondary : 'bg-secondary-500 text-white',
         destructive : 'bg-destructive-500 text-white',
-    }[variant];
+    }[color];
 
     const sizeStyle = {
         xsmall : 'text-xs px-2 py-1',
@@ -38,7 +32,7 @@ const Badge = ({
             aria-label={label}
             className={cn(
                 badgeStyle,
-                variantStyle,
+                colorStyle,
                 sizeStyle,
                 className
             )}
@@ -49,4 +43,4 @@ const Badge = ({
     );
 };
 
-export default Badge;
+export {Badge};

--- a/packages/ui/src/components/Badge/Badge.types.ts
+++ b/packages/ui/src/components/Badge/Badge.types.ts
@@ -1,0 +1,9 @@
+import type { Color, Size } from '../types';
+
+type BadgeSize = Size | 'xsmall';
+
+export interface BadgeProps extends React.ComponentProps<'span'>{
+    color?: Color;
+    size?: BadgeSize;
+    label?: string;
+}

--- a/packages/ui/src/components/Badge/index.ts
+++ b/packages/ui/src/components/Badge/index.ts
@@ -1,2 +1,2 @@
-export { default as Badge } from './Badge';
-export type { BadgeProps } from './Badge';
+export { Badge } from './Badge';
+export type { BadgeProps } from './Badge.types';

--- a/packages/ui/src/components/BreadCrumb/BreadCrumb.stories.tsx
+++ b/packages/ui/src/components/BreadCrumb/BreadCrumb.stories.tsx
@@ -48,7 +48,7 @@ export const Size: Story = {
     render: (args) => {
         return (
             <>
-                <div>small : </div>
+                <div className="mt-4">small : </div>
                 <BreadCrumb {...args} size='small'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -60,7 +60,7 @@ export const Size: Story = {
                         <BreadCrumb.Link href="Component">Component</BreadCrumb.Link>
                     </BreadCrumb.Item>
                 </BreadCrumb>
-                <div>medium : </div>
+                <div className="mt-4">medium : </div>
                 <BreadCrumb {...args} size='medium'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -72,7 +72,7 @@ export const Size: Story = {
                         <BreadCrumb.Link href="Component">Component</BreadCrumb.Link>
                     </BreadCrumb.Item>  
                 </BreadCrumb>
-                <div>large : </div>
+                <div className="mt-4">large : </div>
                 <BreadCrumb {...args} size='large'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -93,7 +93,7 @@ export const color: Story = {
     render: (args) => {
         return (
             <>
-                <div>primary : </div>
+                <div className="mt-4">primary : </div>
                 <BreadCrumb {...args} color='primary'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -105,7 +105,7 @@ export const color: Story = {
                         <BreadCrumb.Link href="Component">Component</BreadCrumb.Link>
                     </BreadCrumb.Item>
                 </BreadCrumb>
-                <div>secondary : </div>
+                <div className="mt-4">secondary : </div>
                 <BreadCrumb {...args} color='secondary'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -126,7 +126,7 @@ export const separator: Story = {
     render: (args) => {
         return (
             <>
-                <div>line : </div>
+                <div className="mt-4">line : </div>
                 <BreadCrumb {...args} separator='line'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>
@@ -138,7 +138,7 @@ export const separator: Story = {
                         <BreadCrumb.Link href="Component">Component</BreadCrumb.Link>
                     </BreadCrumb.Item>
                 </BreadCrumb>
-                <div>arrow : </div>
+                <div className="mt-4">arrow : </div>
                 <BreadCrumb {...args} separator='arrow'>
                     <BreadCrumb.Item >
                         <BreadCrumb.Link href="Home">Home</BreadCrumb.Link>

--- a/packages/ui/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/ui/src/components/BreadCrumb/BreadCrumb.tsx
@@ -1,10 +1,9 @@
-import { forwardRef, createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import React from 'react';
 import { cn } from '../../utils/classname';
 import type{
     BreadCrumbProps,
     BreadCrumbItemProps,
-    BreadCrumbLinkProps,
 } from './BreadCrumb.types';
 
 interface BreadCrumbContextProps {
@@ -15,15 +14,15 @@ interface BreadCrumbContextProps {
 
 const BreadCrumbContext = createContext<BreadCrumbContextProps | undefined>(undefined);
 
-const BreadCrumb = forwardRef<HTMLElement, BreadCrumbProps>(
-({
+const BreadCrumb = ({
     color = 'primary',
     size = 'small',
     separator = 'line',
     className,
     children,
+    ref,
     ...props
-}, ref) => {
+}: BreadCrumbProps) => {
     
     const BreadCrumbListStyle = 'flex flex-wrap items-center break-words';
     const BreadCrumbListSize = {
@@ -59,17 +58,16 @@ const BreadCrumb = forwardRef<HTMLElement, BreadCrumbProps>(
                 </ol>
             </nav>
         </BreadCrumbContext.Provider>
-    )
-});
+    )};
 
 BreadCrumb.displayName = 'BreadCrumb';
 
-const BreadCrumbItem = forwardRef<HTMLLIElement, BreadCrumbItemProps>(({
+const BreadCrumbItem = React.memo(({
     className,
     children,
     isLastItem,
     ...props
-}, ref) => {
+}: BreadCrumbItemProps) => {
     const context = useContext(BreadCrumbContext);
 
     if (!context) {
@@ -87,7 +85,6 @@ const BreadCrumbItem = forwardRef<HTMLLIElement, BreadCrumbItemProps>(({
     return (
         <>
             <li 
-                ref={ref} 
                 className={cn(
                     BreadCrumbItemStyle,
                     BreadcrumbListColor,
@@ -109,17 +106,18 @@ const BreadCrumbItem = forwardRef<HTMLLIElement, BreadCrumbItemProps>(({
                 </li>
             )}
         </>
-    );
+    )
 });
 
 BreadCrumbItem.displayName = 'BreadCrumbItem';
 
-const BreadCrumbLink = forwardRef<HTMLAnchorElement, BreadCrumbLinkProps>(({
+const BreadCrumbLink = ({
     href,
     className,
     children,
+    ref,
     ...props
-}, ref) => {
+}: React.ComponentProps<'a'>) => {
     const context = useContext(BreadCrumbContext);
 
     if (!context) {
@@ -154,7 +152,7 @@ const BreadCrumbLink = forwardRef<HTMLAnchorElement, BreadCrumbLinkProps>(({
             {children}
         </a>
     )
-})
+};
 
 BreadCrumbLink.displayName = 'BreadCrumbLink';
     

--- a/packages/ui/src/components/BreadCrumb/BreadCrumb.types.ts
+++ b/packages/ui/src/components/BreadCrumb/BreadCrumb.types.ts
@@ -1,18 +1,13 @@
-import { HTMLAttributes, LiHTMLAttributes, AnchorHTMLAttributes } from 'react';
+import type { Color, Size } from '../types';
 
-export interface BreadCrumbProps extends HTMLAttributes<HTMLElement> {
-    color?: 'primary' | 'secondary';
-    size?: 'small' | 'medium' | 'large';
+type BreadCrumbColor = Exclude<Color, 'destructive'>;
+
+export interface BreadCrumbProps extends React.ComponentProps<'nav'> {
+    color?: BreadCrumbColor;
+    size?: Size;
     separator?: 'line' | 'arrow';
-    className?: string;
 }
 
-export interface BreadCrumbItemProps extends LiHTMLAttributes<HTMLLIElement> {
+export interface BreadCrumbItemProps extends React.ComponentProps<'li'> {
     isLastItem?: boolean;
-    className?: string;
-}
-
-export interface BreadCrumbLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
-    href: string;
-    className?: string;
 }

--- a/packages/ui/src/components/BreadCrumb/index.ts
+++ b/packages/ui/src/components/BreadCrumb/index.ts
@@ -7,7 +7,6 @@ import {
 import type {
     BreadCrumbProps,
     BreadCrumbItemProps,
-    BreadCrumbLinkProps,
 } from './BreadCrumb.types';
 
 
@@ -16,11 +15,9 @@ const BreadCrumb = Object.assign(BreadCrumbComponent, {
     Link: BreadCrumbLink,
 });
 
-
 export { BreadCrumb };
 
 export type{
     BreadCrumbProps,
     BreadCrumbItemProps,
-    BreadCrumbLinkProps,
 };

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,21 +1,8 @@
-import { ButtonHTMLAttributes, forwardRef } from 'react';
+import * as React from 'react';
 import { cn } from '../../utils/classname';
+import type { ButtonProps } from './Button.types';
 
-export type ButtonVariant = 'outline' | 'ghost' | 'default';
-export type ButtonColor = 'primary' | 'secondary' | 'destructive' | 'default';
-export type ButtonSize = 'small' | 'medium' | 'large' | 'icon';
-
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant;
-  color?: ButtonColor;
-  size?: ButtonSize;
-  isLoading?: boolean;
-  className?: string;
-}
-
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
+const Button = React.memo(({
       className,
       variant = 'default',
       color = 'default',
@@ -23,10 +10,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       isLoading = false,
       disabled,
       children,
+      ref,
       ...props
-    },
-    ref
-  ) => {
+    }: ButtonProps) => {
     const buttonBaseStyle =
       "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0";
 

--- a/packages/ui/src/components/Button/Button.types.ts
+++ b/packages/ui/src/components/Button/Button.types.ts
@@ -1,0 +1,12 @@
+import type { Color, Size } from '../types';
+
+type ButtonVariant = 'outline' | 'ghost' | 'default';
+type ButtonColor = Color | 'default';
+type ButtonSize = Size | 'icon';
+
+export interface ButtonProps extends React.ComponentProps<'button'> {
+    variant?: ButtonVariant;
+    color?: ButtonColor;
+    size?: ButtonSize;
+    isLoading?: boolean;
+  }

--- a/packages/ui/src/components/Button/index.ts
+++ b/packages/ui/src/components/Button/index.ts
@@ -1,2 +1,2 @@
 export { Button } from "./Button";
-export type { ButtonVariant, ButtonColor, ButtonSize } from "./Button";
+export type { ButtonProps } from "./Button.types";

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,18 +1,17 @@
-import { forwardRef, useState } from 'react';
+import * as React from "react";
+import { useState } from 'react';
 import { cn } from '../../utils/classname';
 import { Button } from '../Button/Button';
 import CloseIcon from '../../assets/icons/close.svg';
-import { 
-  CardProps, 
-  CardHeaderProps, 
-  CardTitleProps, 
-  CardDescriptionProps, 
-  CardContentProps, 
-  CardFooterProps 
-} from './Card.types';
+import type { CardProps } from './Card.types';
 
-const Card = forwardRef<HTMLDivElement, CardProps>(
-  ({ className, closable = false, onClose, ...props }, ref) => {    
+const Card = ({ 
+  className, 
+  closable = false, 
+  onClose, 
+  ref,
+  ...props 
+}: CardProps) => {    
     const [isVisible, setIsVisible] = useState(true);
 
     const handleClose = () => {
@@ -49,12 +48,14 @@ const Card = forwardRef<HTMLDivElement, CardProps>(
         {props.children}
       </div>
     );
-  }
-);
+  };
 Card.displayName = "Card";
 
-const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
-  ({ className, ...props }, ref) => {
+const CardHeader = React.memo(({ 
+  className, 
+  ref,
+  ...props 
+}: React.ComponentProps<'div'>) => {
     return (
       <div
         ref={ref}
@@ -66,8 +67,11 @@ const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
 );
 CardHeader.displayName = "CardHeader";
 
-const CardTitle = forwardRef<HTMLHeadingElement, CardTitleProps>(
-  ({ className, ...props }, ref) => {
+const CardTitle = React.memo(({ 
+  className, 
+  ref,
+  ...props 
+}: React.ComponentProps<'h3'>) => {
     return (
       <h3
         ref={ref}
@@ -82,8 +86,11 @@ const CardTitle = forwardRef<HTMLHeadingElement, CardTitleProps>(
 );
 CardTitle.displayName = "CardTitle";
 
-const CardDescription = forwardRef<HTMLParagraphElement, CardDescriptionProps>(
-  ({ className, ...props }, ref) => {
+const CardDescription = React.memo(({ 
+  className, 
+  ref,
+  ...props 
+}: React.ComponentProps<'p'>) => {
     return (
       <p
         ref={ref}
@@ -95,8 +102,11 @@ const CardDescription = forwardRef<HTMLParagraphElement, CardDescriptionProps>(
 );
 CardDescription.displayName = "CardDescription";
 
-const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
-  ({ className, ...props }, ref) => {
+const CardContent = React.memo(({ 
+  className,
+  ref, 
+  ...props 
+}: React.ComponentProps<'div'>) => {
     return (
       <div
         ref={ref}
@@ -108,8 +118,11 @@ const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
 );
 CardContent.displayName = "CardContent";
 
-const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
-  ({ className, ...props }, ref) => {
+const CardFooter = React.memo(({ 
+  className, 
+  ref,
+  ...props 
+}: React.ComponentProps<'div'>) => {
     return (
       <div
         ref={ref}

--- a/packages/ui/src/components/Card/Card.types.ts
+++ b/packages/ui/src/components/Card/Card.types.ts
@@ -1,27 +1,4 @@
-import { HTMLAttributes } from 'react';
-
-export interface CardProps extends HTMLAttributes<HTMLDivElement> {
-  className?: string;
+export interface CardProps extends React.ComponentProps<'div'> {
   closable?: boolean;
   onClose?: () => void;
 }
-
-export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
-  className?: string;
-}
-
-export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
-  className?: string;
-}
-
-export interface CardDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {
-  className?: string;
-}
-
-export interface CardContentProps extends HTMLAttributes<HTMLDivElement> {
-  className?: string;
-}
-
-export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {
-  className?: string;
-} 

--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -7,14 +7,7 @@ import {
   CardFooter 
 } from "./Card";
 
-import type { 
-  CardProps, 
-  CardHeaderProps, 
-  CardTitleProps, 
-  CardDescriptionProps, 
-  CardContentProps, 
-  CardFooterProps 
-} from "./Card.types";
+import type { CardProps } from "./Card.types";
 
 // Card 컴포넌트에 하위 컴포넌트를 속성으로 추가
 const Card = Object.assign(CardComponent, {
@@ -27,11 +20,4 @@ const Card = Object.assign(CardComponent, {
 
 export { Card };
 
-export type {
-  CardProps,
-  CardHeaderProps,
-  CardTitleProps,
-  CardDescriptionProps,
-  CardContentProps,
-  CardFooterProps
-}; 
+export type { CardProps }; 

--- a/packages/ui/src/components/Chart/Chart.stories.tsx
+++ b/packages/ui/src/components/Chart/Chart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { ChartComponent } from './Chart';
-import { ChartProps } from './Chart.types';
+import type { ChartProps } from './Chart.types';
 
 const meta: Meta<ChartProps> = {
   title: 'Components/Chart',

--- a/packages/ui/src/components/Chart/Chart.tsx
+++ b/packages/ui/src/components/Chart/Chart.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import { useEffect, useRef, useMemo } from 'react';
 import { Chart as ChartJS, registerables } from 'chart.js';
 import { Chart } from 'chart.js/auto';
-import { ChartProps } from './Chart.types';
+import type { ChartProps } from './Chart.types';
 
 ChartJS.register(...registerables);
 
@@ -10,14 +11,14 @@ const emptyChartData = {
   datasets: []
 };
 
-const ChartComponent: React.FC<ChartProps> = ({ 
+const ChartComponent = React.memo(({ 
   type, 
   data, 
   options = {}, 
   width = '100%', 
   height = '300px',
   updateMode = 'default'
-}) => {
+}: ChartProps) => {
   const chartRef = useRef<HTMLCanvasElement>(null);
   const chartInstance = useRef<Chart | null>(null);
 
@@ -66,6 +67,6 @@ const ChartComponent: React.FC<ChartProps> = ({
   return (
     <canvas ref={chartRef} width={width} height={height} />
   );
-};
+});
 
 export { ChartComponent };

--- a/packages/ui/src/components/Chart/Chart.types.ts
+++ b/packages/ui/src/components/Chart/Chart.types.ts
@@ -2,12 +2,9 @@ import { ChartData, ChartOptions } from 'chart.js';
 
 export type ChartUpdateMode = 'default' | 'reset' | 'resize' | 'none';
 
-export interface ChartProps {
+export interface ChartProps extends React.ComponentProps<'canvas'> {
   type: 'bar' | 'line' | 'pie' | 'radar' | 'doughnut' | 'polarArea' | 'scatter'; 
   data: ChartData;
   options?: ChartOptions;
-  width?: string;
-  height?: string;
-  
   updateMode?: ChartUpdateMode;
 } 

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof Checkbox> = {
     component: Checkbox,
     tags: ['autodocs'],
     argTypes:{
-        variant:{
+        color:{
             control: 'select',
             options: ['primary', 'secondary']
         },
@@ -19,7 +19,7 @@ const meta: Meta<typeof Checkbox> = {
             options: ['rectangle', 'circle']
         },
         disabled:{
-            boolean: false,
+            control: 'boolean',
         }
     }
 
@@ -30,26 +30,62 @@ export default meta;
 type Story = StoryObj<typeof Checkbox>;
 
 export const Default: Story = {
-    args:{
-        variant: 'primary',
-        size: 'small',
-        type: 'circle',
-        label: 'checkbox'
-    }
+    args: {
+        color: "primary",
+        size: "small",
+        type: "rectangle",
+        label: "checkbox",
+    },
+}
+
+export const Colors: Story = {
+    render: () => (
+        <>
+            <div className="mt-4 mb-2">Color: primary</div>
+            <Checkbox color="primary" label="색상 primary"/>
+
+            <div className="mt-4 mb-2">Color: Secondary</div>
+            <Checkbox color="secondary" label="색상 secondary"/>
+        </>
+    ),
+}
+
+export const Sizes: Story = {
+    render: () => (
+        <>
+            <div className="mt-4 mb-2">Size: small</div>
+            <Checkbox size="small" label="small"/>
+
+            <div className="mt-4 mb-2">Size: medium</div>
+            <Checkbox size="medium" label="medium"/>
+
+            <div className="mt-4 mb-2">Size: large</div>
+            <Checkbox size="large" label="large"/>
+        </>
+    ),
+}
+
+export const Types: Story = {
+    render: () => (
+        <>
+            <div className="mt-4 mb-2">Type: rectangle</div>
+            <Checkbox type="rectangle" label="checkbox 사각형"/>
+
+            <div className="mt-4 mb-2">Type: circle</div>
+            <Checkbox type="circle" label="checkbox 원형"/>
+        </>
+    ),
 }
 
 export const OnlyInput: Story = {
-    args:{
-        variant: 'primary',
-        size: 'small',
-    }
+    render: (args) => (
+        <Checkbox {...args} />
+    ),
 }
 
+
 export const Disabled: Story = {
-    args:{
-        variant: 'primary',
-        size: 'small',
-        label: 'checkbox',
-        disabled: true
-    }
+    render: (args) => (
+        <Checkbox {...args} disabled={true} label="비활성화"/>
+    ),
 }

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -1,17 +1,9 @@
-import { useState, HTMLAttributes } from "react";
+import { useState } from "react";
 import { cn } from "../../utils/classname";
-
-export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
-  variant?: "primary" | "secondary";
-  size?: "small" | "medium" | "large";
-  type?: "rectangle" | "circle";
-  label?: string;
-  className?: string;
-  disabled?: boolean;
-}
+import type { CheckboxProps } from "./Checkbox.types";
 
 const Checkbox = ({
-  variant = "primary",
+  color = "primary",
   size = "small",
   type = "rectangle",
   label,
@@ -41,7 +33,7 @@ const Checkbox = ({
   const inputVariantStyle = {
     primary: `${checked ? "bg-primary-500 border-primary-600" : ""}`,
     secondary: `${checked ? "bg-secondary-500 border-secondary-600" : ""}`,
-  }[variant];
+  }[color];
 
   const inputDisabledStyle = disabled ? "bg-gray-200 border-gray-400 after:border-gray-400 cursor-not-allowed" : "";
 
@@ -56,7 +48,7 @@ const Checkbox = ({
   const labelVariantStyle = {
     primary: "text-black",
     secondary: "text-black",
-  }[variant];
+  }[color];
 
   const labelDisabledStyle = disabled ? "text-gray-400 cursor-not-allowed" : "";
 
@@ -98,5 +90,7 @@ const Checkbox = ({
     </label>
   );
 };
+
+Checkbox.displayname = 'Checkbox';
 
 export default Checkbox;

--- a/packages/ui/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/ui/src/components/Checkbox/Checkbox.types.ts
@@ -1,0 +1,10 @@
+import type { Color, Size } from '../types';
+
+type CheckboxColor = Exclude<Color, 'destructive'>;
+
+export interface CheckboxProps extends Omit<React.ComponentProps<'input'>, 'size' | 'type'> {
+    color?: CheckboxColor;
+    size?: Size;
+    type?: "rectangle" | "circle";
+    label?: string;
+}

--- a/packages/ui/src/components/Checkbox/index.ts
+++ b/packages/ui/src/components/Checkbox/index.ts
@@ -1,2 +1,2 @@
 export {default as Checkbox} from "./Checkbox";
-export type { CheckboxProps } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox.types";

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -1,18 +1,18 @@
-import React, { forwardRef, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '../../utils/classname';
 import { DialogProps } from './Dialog.types';
 
-const Dialog = forwardRef<HTMLDivElement, DialogProps>(
-  ({ 
+const Dialog = React.memo(({ 
     isOpen, 
     onClose, 
     children, 
     overlayClassName,
     contentClassName,
     closeOnOverlayClick = true,
-    closeOnEsc = true
-  }, ref) => {
+    closeOnEsc = true,
+    ref,
+  }: DialogProps) => {
     const dialogRef = useRef<HTMLDivElement>(null);
     const mergedRef = (node: HTMLDivElement) => {
       dialogRef.current = node;

--- a/packages/ui/src/components/Dialog/Dialog.types.ts
+++ b/packages/ui/src/components/Dialog/Dialog.types.ts
@@ -8,4 +8,5 @@ export interface DialogProps {
   contentClassName?: string;
   closeOnOverlayClick?: boolean;
   closeOnEsc?: boolean;
+  ref?: React.Ref<HTMLDivElement>;
 } 

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -1,19 +1,9 @@
 import * as React from "react";
 import { useState } from "react";
 import { cn } from "../../utils/classname";
+import { InputProps } from "./Input.types"
 
-export interface InputProps extends React.ComponentProps<'input'> {
-    id?: string;
-    ariaLabel?: string;
-    invalid?: boolean;
-    iconPosition?: 'leading' | 'trailing';
-    iconSvg?: string | React.ComponentType<React.SVGProps<SVGSVGElement>>;
-    renderIcon?: (props: {iconColor: string, isFocused: boolean}) => React.ReactNode;
-    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    className?: string;
-}
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({
+const Input = ({
     id,
     ariaLabel,
     type = 'text',
@@ -24,8 +14,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
     value,
     onChange,
     className,
+    ref,
     ...props
-}, ref) => {
+}: InputProps) => {
   const [inputFocus, setInputFocus] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {onChange?.(e);};
@@ -81,7 +72,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
       </div>
     </>
   );
-});
+};
 
 Input.displayName = 'Input';
 

--- a/packages/ui/src/components/Input/Input.types.ts
+++ b/packages/ui/src/components/Input/Input.types.ts
@@ -1,0 +1,12 @@
+export interface InputProps extends React.ComponentProps<'input'> {
+    ariaLabel?: string;
+    invalid?: boolean;
+    iconPosition?: 'leading' | 'trailing';
+    iconSvg?: string | React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    renderIcon?: (props: {iconColor: string, isFocused: boolean}) => React.ReactNode;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+  export interface InputHelperTextProps extends React.ComponentProps<'p'> {
+    error?: boolean;
+  }

--- a/packages/ui/src/components/Input/InputBox.tsx
+++ b/packages/ui/src/components/Input/InputBox.tsx
@@ -1,25 +1,21 @@
 import * as React from "react";
-import { useRef } from "react";
-import { v4 as uuidv4 } from "uuid";
+import { useId } from "react";
 import { cn } from "../../utils/classname";
 import { InputHelperText } from "./InputHelperText";
 import { InputLabel } from "./InputLabel";
 import { InputText } from "./InputText";
 import { InputPassword } from "./InputPassword";
 
-export interface InputBoxProps extends React.HTMLAttributes<HTMLDivElement>{
-  className?: string;
-}
-
-const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(({
+const InputBox = ({
   children,
   className,
+  ref,
   ...props
-}, ref) => {
+}: React.ComponentProps<'div'>) => {
 
-  const uniqueIdRef = useRef(uuidv4());
-  const inputId = `input-${uniqueIdRef.current}`;
-  const helperId = `helper-${uniqueIdRef.current}`;
+  const uniqueId = useId();
+  const inputId = `input-${uniqueId}`;
+  const helperId = `helper-${uniqueId}`;
   
   const inputChildren = React.Children.toArray(children);
   const inputHelperTexts = inputChildren.filter(child => React.isValidElement(child) && child.type === InputHelperText);
@@ -63,7 +59,7 @@ const InputBox = React.forwardRef<HTMLDivElement, InputBoxProps>(({
       {helperTextsProp}
     </div>
   );
-});
+};
 
 InputBox.displayName = 'InputBox';
 

--- a/packages/ui/src/components/Input/InputHelperText.tsx
+++ b/packages/ui/src/components/Input/InputHelperText.tsx
@@ -1,19 +1,14 @@
-import * as React from "react";
 import { cn } from "../../utils/classname";
+import { InputHelperTextProps } from "./Input.types";
 
-export interface InputHelperTextProps extends React.ComponentProps<'p'> {
-  id?: string;
-  error?: boolean;
-  className?: string;
-}
-
-const InputHelperText = React.forwardRef<HTMLParagraphElement, InputHelperTextProps>(({
+const InputHelperText = ({
   children,
   id,
   error = false,
   className,
+  ref,
   ...props
-}, ref) => {
+}: InputHelperTextProps) => {
 
   const helperTextStyle = "text-xs my-1";
   const helperTextError = error ? "text-red-600" : "text-gray-500";
@@ -32,7 +27,7 @@ const InputHelperText = React.forwardRef<HTMLParagraphElement, InputHelperTextPr
       {children}
     </p>
   );
-});
+};
 
 InputHelperText.displayName = 'InputHelperText';
 

--- a/packages/ui/src/components/Input/InputLabel.tsx
+++ b/packages/ui/src/components/Input/InputLabel.tsx
@@ -1,17 +1,12 @@
-import * as React from "react";
 import { cn } from "../../utils/classname";
 
-export interface InputLabelProps extends React.ComponentProps<'label'> {
-  id?: string;
-  className?: string;
-}
-
-const InputLabel = React.forwardRef<HTMLLabelElement, InputLabelProps>(({
+const InputLabel = ({
   children,
   id,
   className,
+  ref,
   ...props
-}, ref) => {
+}: React.ComponentProps<'label'>) => {
   return (
     <label
       ref={ref}
@@ -25,7 +20,7 @@ const InputLabel = React.forwardRef<HTMLLabelElement, InputLabelProps>(({
       {children}
     </label>
   );
-});
+};
 
 InputLabel.displayName = 'InputLabel';
 

--- a/packages/ui/src/components/Input/InputPassword.tsx
+++ b/packages/ui/src/components/Input/InputPassword.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
-import { Input, InputProps } from './Input';
+import { Input } from './Input';
+import { InputProps } from "./Input.types";
 import PasswordIcon from "../../assets/icons/password.svg";
 import HidePasswordIcon from "../../assets/icons/password_hide.svg";
 

--- a/packages/ui/src/components/Input/InputText.tsx
+++ b/packages/ui/src/components/Input/InputText.tsx
@@ -1,11 +1,15 @@
-import * as React from "react";
+import { Input } from './Input';
+import { InputProps } from "./Input.types";
 
-import { Input, InputProps } from './Input';
-
-const InputText = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
-  return <Input type="text" ref={ref} {...props} />;
-});
-
+const InputText = ({
+  ref,
+  ...props
+}: InputProps) => {
+  return (
+    <Input type="text" ref={ref} {...props} />
+  )
+}
+  
 InputText.displayName = 'InputText';
 
 export { InputText };

--- a/packages/ui/src/components/Input/index.ts
+++ b/packages/ui/src/components/Input/index.ts
@@ -1,15 +1,17 @@
+import { Input as InputComponent } from './Input';
 import { InputPassword } from "./InputPassword";
 import { InputText } from "./InputText";
 import { InputLabel } from "./InputLabel";
 import { InputHelperText } from "./InputHelperText";
 import { InputBox } from "./InputBox";
 
-const Input = () => null;
-Input.Text = InputText;
-Input.Password = InputPassword;
-Input.Label = InputLabel;
-Input.HelperText = InputHelperText;
-Input.Box = InputBox;
+const Input = Object.assign(InputComponent, {
+  Text: InputText,
+  Password: InputPassword,
+  Label: InputLabel,
+  HelperText: InputHelperText,
+  Box: InputBox
+});
 
 export { Input };
-export type { InputProps } from './Input';
+export type { InputProps } from './Input.types';

--- a/packages/ui/src/components/Label/Label.stories.tsx
+++ b/packages/ui/src/components/Label/Label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Label } from './Label';
-import Input from '../Input';
+import { Input } from '../Input';
 
 const meta: Meta<typeof Label> = {
     title: 'Components/Label',
@@ -19,33 +19,36 @@ export const Default: Story = {
         children: '기본 라벨 텍스트입니다.'
     }
 }
-export const Disabled: Story = {
-    render: (args) => (
-        <Label {...args} htmlFor="label-id2" disabled></Label>
-    ),
-    args:{
-        children: '비활성화 상태'
-    }
+
+export const Sizes: Story = {
+    render: () => (
+        <>
+            <div className="mt-4">Small:</div>
+            <Label htmlFor="label-id2" size='small'>Small Size</Label>
+            <div className="mt-4">Medium:</div>
+            <Label htmlFor="label-id3" size='medium'>Medium Size</Label>
+            <div className="mt-4">Large:</div>
+            <Label htmlFor="label-id4" size='large'>Large Size</Label>
+        </>
+    )
 }
-export const Error: Story = {
-    render: (args) => (
-        <Label {...args} htmlFor="label-id3" error></Label>
-    ),
-    args:{
-        children: '에러 상태'
-    }
+
+export const Colors: Story = {
+    render: () => (
+        <>
+            <div className="mt-4">Small:</div>
+            <Label htmlFor="label-id5" color='primary'>Small Size</Label>
+            <div className="mt-4">Medium:</div>
+            <Label htmlFor="label-id6" color='secondary'>Medium Size</Label>
+            <div className="mt-4">Large:</div>
+            <Label htmlFor="label-id7" color='destructive'>Large Size</Label>
+        </>
+    )
 }
-export const Focused: Story = {
-    render: (args) => (
-        <Label {...args} htmlFor="label-id3" focused></Label>
-    ),
-    args:{
-        children: '포커스 상태'
-    }
-}
+
 export const Required: Story = {
     render: (args) => (
-        <Label {...args} htmlFor="label-id4" required></Label>
+        <Label {...args} htmlFor="label-id8" required></Label>
     ),
     args:{
         children: '필수 입력 상태'
@@ -55,8 +58,8 @@ export const Required: Story = {
 export const WithInput: Story = {
     render: (args) => (
         <div className="flex gap-1 items-center">
-            <Label {...args} htmlFor="label-id5" required></Label>
-            <Input.Text id="label-id5" placeholder="텍스트를 입력하세요" />
+            <Label {...args} htmlFor="label-id9" required></Label>
+            <Input.Text id="label-id9" placeholder="텍스트를 입력하세요" />
         </div>
     ),
     args:{

--- a/packages/ui/src/components/Label/Label.tsx
+++ b/packages/ui/src/components/Label/Label.tsx
@@ -1,16 +1,15 @@
-import * as React from "react";
 import { cn } from "../../utils/classname";
 import type { LabelProps } from "./Label.types";
 
-const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
-({
+const Label = ({
     color = "primary",
     required,
     size = "medium",
     className,
     children,
+    ref,
     ...props
-}, ref) => {
+}: LabelProps) => {
 
     const labelColor = {
         primary: "text-primary-500",
@@ -40,7 +39,8 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
          {children}   
         </label>
     )
-})
+};
 
 Label.displayName = "Label";
+
 export { Label };

--- a/packages/ui/src/components/Label/Label.types.ts
+++ b/packages/ui/src/components/Label/Label.types.ts
@@ -1,8 +1,8 @@
 
-import { LabelHTMLAttributes } from "react";
-export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
-    color?: "primary" | "secondary" | "destructive";
+import type { Color, Size } from '../types'
+
+export interface LabelProps extends React.ComponentProps<'label'> {
+    color?: Color;
     required?: boolean;
-    size?: "small" | "medium" | "large";
-    className?: string;
+    size?: Size;
 }

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,12 +1,11 @@
-import { forwardRef } from 'react';
+import React from 'react';
 import { Dialog } from '../Dialog/Dialog';
 import { Button } from '../Button/Button';
 import { cn } from '../../utils/classname';
 import CloseIcon from '../../assets/icons/close.svg';
 import { ModalProps } from './Modal.types';
 
-const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ 
+const Modal = React.memo(({ 
     children, 
     title, 
     footer, 
@@ -17,8 +16,9 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     headerClassName,
     bodyClassName,
     footerClassName,
+    ref,
     ...props 
-  }, ref) => {
+  }: ModalProps) => {
     const widthClass = typeof width === 'number' ? `w-[${width}px]` : `w-[${width}]`;
     const heightClass = typeof height === 'number' ? `h-[${height}px]` : `h-[${height}]`;
 

--- a/packages/ui/src/components/Modal/Modal.types.ts
+++ b/packages/ui/src/components/Modal/Modal.types.ts
@@ -11,4 +11,5 @@ export interface ModalProps extends Omit<DialogProps, 'contentClassName'> {
   headerClassName?: string;
   bodyClassName?: string;
   footerClassName?: string;
+  ref?: React.Ref<HTMLDivElement>;
 } 

--- a/packages/ui/src/components/Popup/Popup.tsx
+++ b/packages/ui/src/components/Popup/Popup.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import React from 'react';
 import { Dialog } from '../Dialog/Dialog';
 import { Button } from '../Button/Button';
 import { cn } from '../../utils/classname';
@@ -25,8 +25,7 @@ const getPlacementClasses = (placement: PopupPlacement): string => {
   }
 };
 
-const Popup = forwardRef<HTMLDivElement, PopupProps>(
-  ({ 
+const Popup = React.memo(({ 
     children, 
     title, 
     placement = 'center', 
@@ -36,8 +35,9 @@ const Popup = forwardRef<HTMLDivElement, PopupProps>(
     headerClassName,
     bodyClassName,
     overlayClassName,
+    ref,
     ...props 
-  }, ref) => {
+  }: PopupProps) => {
     const widthClass = typeof width === 'number' ? `w-[${width}px]` : `w-[${width}]`;
 
     return (
@@ -93,8 +93,7 @@ const Popup = forwardRef<HTMLDivElement, PopupProps>(
         </div>
       </Dialog>
     );
-  }
-);
+  });
 
 Popup.displayName = 'Popup';
 

--- a/packages/ui/src/components/Popup/Popup.types.ts
+++ b/packages/ui/src/components/Popup/Popup.types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DialogProps } from '../Dialog/Dialog.types';
+import type { DialogProps } from '../Dialog/Dialog.types';
 
 export type PopupPlacement = 'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'center';
 
@@ -11,4 +11,5 @@ export interface PopupProps extends Omit<DialogProps, 'contentClassName'> {
   contentClassName?: string;
   headerClassName?: string;
   bodyClassName?: string;
+  ref?: React.Ref<HTMLDivElement>;
 } 

--- a/packages/ui/src/components/Radio/Radio.tsx
+++ b/packages/ui/src/components/Radio/Radio.tsx
@@ -1,36 +1,26 @@
-import * as React from "react";
-import { useState, createContext, useContext, ReactNode } from "react";
+import { useState, createContext, useContext } from "react";
 import { cn } from "../../utils/classname";
+import type { RadioGroupProps, RadioItemProps } from "./Radio.types";
 
 interface RadioGroupContextProps {
   selectedValue: string | null;
   onChange: (value: string) => void;
-  variant: "primary" | "secondary";
-  size: "small" | "medium" | "large";
+  color: string;
+  size: string;
   name: string;
 }
-
 const RadioGroupContext = createContext<RadioGroupContextProps | undefined>(undefined);
 
-export interface RadioGroupProps {
-  defaultValue?: string;
-  variant?: "primary" | "secondary";
-  size?: "small" | "medium" | "large";
-  name:string;
-  onChange: (value: string) => void;
-  children: ReactNode;
-  className?: string;
-}
-
-const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(({
+const RadioGroup = ({
   defaultValue,
-  variant = "primary",
+  color = "primary",
   size = "small",
   onChange,
   name,
   children,
+  ref,
   ...props
-}, ref) => {
+}: RadioGroupProps) => {
 
   const [internalValue, setInternalValue] = useState<string | null>(defaultValue || null);
 
@@ -40,7 +30,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(({
   };
 
   return (
-    <RadioGroupContext.Provider value={{ selectedValue: internalValue, onChange: handleChange, variant, size, name }}>
+    <RadioGroupContext.Provider value={{ selectedValue: internalValue, onChange: handleChange, color, size, name }}>
       <div 
           role="radiogroup" 
           className={cn("grid gap-2", props.className)} 
@@ -51,31 +41,26 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(({
       </div>
     </RadioGroupContext.Provider>
   );
-});
+}; 
 
-export interface RadioItemProps extends React.HTMLAttributes<HTMLLabelElement> {
-  value: string;
-  label?: string;
-  disabled?: boolean;
-  className?: string;
-}
+RadioGroup.displayName = "RadioGroup";
 
-const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
+const RadioGroupItem = ({
   value,
   label,
   disabled = false,
   className,
+  ref,
   ...props
-}, ref) => {
+}: RadioItemProps) => {
 
-  
   const context = useContext(RadioGroupContext);
 
   if (!context) {
     throw new Error("RadioGroupItem은 RadioGroup 내에서 사용되어야 합니다.");
   }
 
-  const { selectedValue, onChange, variant, size, name } = context;
+  const { selectedValue, onChange, color, size, name } = context;
 
   const inputStyle = "z-1 inline-block cursor-pointer border-1 bg-white border-gray-500 rounded-full relative after:absolute after:top-1/2 after:left-1/2 after:transform after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full after:border-full after:transform";
 
@@ -88,7 +73,7 @@ const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
   const inputVariantStyle = {
       primary: `${selectedValue === value ? "border-primary-500 after:bg-primary-500" : ""}`,
       secondary: `${selectedValue === value ? "border-secondary-500 after:bg-secondary-500" : ""}`,
-  }[variant];
+  }[color];
 
   const inputDisabledStyle = disabled ? `bg-gray-200 border-gray-400 cursor-not-allowed ${selectedValue === value ? "after:bg-gray-400" : ""}` : "";
 
@@ -102,7 +87,7 @@ const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
   const labelVariantStyle = {
     primary: "text-black",
     secondary: "text-black",
-  }[variant];
+  }[color];
 
   const labelDisabledStyle = disabled ? "text-gray-400 cursor-not-allowed" : "";
 
@@ -115,7 +100,6 @@ const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
 
   return (
     <label
-      ref={ref}
       className={cn(
         labelStyle,
         labelSizeStyle,
@@ -126,6 +110,7 @@ const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
       {...props}
     >
       <input
+        ref={ref}
         type="radio"
         className="absolute opacity-0 z-1"
         disabled={disabled}
@@ -146,9 +131,8 @@ const RadioGroupItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(({
       {label}
     </label>
   );
-});
+};
 
 RadioGroupItem.displayName = "RadioGroupItem";
-RadioGroup.displayName = "RadioGroup";
 
 export { RadioGroup, RadioGroupItem };

--- a/packages/ui/src/components/Radio/Radio.types.ts
+++ b/packages/ui/src/components/Radio/Radio.types.ts
@@ -1,0 +1,19 @@
+import type { Color, Size } from '../types';
+
+type RadioColor = Exclude<Color, 'destructive'>;
+
+export interface RadioGroupProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
+    defaultValue?: string;
+    variant?: RadioColor;
+    size?: Size;
+    name: string;
+    onChange: (value: string) => void;
+    children: React.ReactNode;
+}
+
+export interface RadioItemProps extends Omit<React.ComponentProps<'label'>, 'ref'> {
+    value: string;
+    label?: React.ReactNode;
+    disabled?: boolean;
+    ref?: React.Ref<HTMLInputElement>;
+}

--- a/packages/ui/src/components/Radio/index.ts
+++ b/packages/ui/src/components/Radio/index.ts
@@ -1,2 +1,2 @@
 export { RadioGroup, RadioGroupItem } from "./Radio";
-export type { RadioGroupProps, RadioItemProps as RadioGroupItemProps } from "./Radio";
+export type { RadioGroupProps, RadioItemProps } from "./Radio.types";

--- a/packages/ui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton/Skeleton.tsx
@@ -1,17 +1,14 @@
-import * as React from 'react';
 import { cn } from '../../utils/classname';
 import type { SkeletonProps } from './Skeleton.types';
 
-const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
-({
+const Skeleton = ({
     variant = "rectangle",
     className,
     ...props
-}, ref) => {
+}: SkeletonProps ) => {
     return(
         <div 
             aria-busy="true"
-            ref={ref}
             className={cn(
                 "animate-pulse rounded-md bg-muted bg-gray-200",
                 variant === "circle" && "rounded-full",
@@ -19,12 +16,11 @@ const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
                 variant === "text" && "h-4 w-full rounded",
                 className
             )}
-            
             {...props}
         >
         </div>
     )
-});
+};
 
 Skeleton.displayName = "Skeleton";
 

--- a/packages/ui/src/components/Skeleton/Skeleton.types.ts
+++ b/packages/ui/src/components/Skeleton/Skeleton.types.ts
@@ -1,4 +1,3 @@
-export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface SkeletonProps extends React.ComponentProps<'div'> {
     variant?: "circle" | "rectangle" | "text";
-    className?: string;
 }

--- a/packages/ui/src/components/Slider/Slider.stories.tsx
+++ b/packages/ui/src/components/Slider/Slider.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Slider } from './';
+import { Slider } from '../Slider';
 
 const meta: Meta<typeof Slider> = {
     title: 'Components/Slider',
@@ -76,7 +76,6 @@ export const Colors: Story = {
     ),
 };
 
-
 export const Customize: Story = {
     render: () => (
         <div className="p-4 w-96 relative">
@@ -101,6 +100,19 @@ export const Customize: Story = {
                     <Slider.Range />
                 </Slider>
             </div>
+        </div>
+    ),
+};
+
+export const Disabled: Story = {
+    render: () => (
+        <div className="p-4 w-96 relative">
+            <Slider disabled={true} defaultValue={40}>
+                <Slider.Track>
+                    <Slider.Thumb size="large" />
+                </Slider.Track>
+                <Slider.Range />
+            </Slider>
         </div>
     ),
 };

--- a/packages/ui/src/components/Slider/Slider.tsx
+++ b/packages/ui/src/components/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useCallback, useId, useState, useEffect, useRef } from 'react';
 import { cn } from '../../utils/classname';
 import type {

--- a/packages/ui/src/components/Slider/Slider.types.ts
+++ b/packages/ui/src/components/Slider/Slider.types.ts
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { Color, Size } from '../types';
+
+type SliderColor = Exclude<Color, 'destructive'>;
 
 export interface SliderContextProps {
     disabled?: boolean;
@@ -7,13 +9,13 @@ export interface SliderContextProps {
     min: number;
     max: number;
     step: number;
-    size: 'small' | 'medium' | 'large';
-    color: 'primary' | 'secondary';
+    size: Size;
+    color: SliderColor;
     sliderId: string;
     sliderRef: { current: HTMLDivElement | null };
 }
 
-export interface SliderProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface SliderProps extends React.ComponentProps<'div'> {
     defaultValue?: number;
     value?: number;
     onValueChange?: (value: number) => void;
@@ -21,25 +23,21 @@ export interface SliderProps extends React.HTMLAttributes<HTMLDivElement> {
     max?: number;
     step?: number;
     disabled?: boolean;
-    size?: 'small' | 'medium' | 'large';
-    color?: 'primary' | 'secondary';
-    className?: string;
+    size?: Size;
+    color?: SliderColor;
     'aria-label'?: string;
     'aria-labelledby'?: string;
 }
 
-export interface SliderTrackProps extends React.HTMLAttributes<HTMLDivElement> {
-    className?: string;
+export interface SliderTrackProps extends React.ComponentProps<'div'> {
     children?: React.ReactNode;
 }
 
-export interface SliderThumbProps extends React.HTMLAttributes<HTMLSpanElement> {
-    className?: string;
+export interface SliderThumbProps extends React.ComponentProps<'span'> {
     tabIndex?: number;
-    size?: 'small' | 'medium' | 'large';
+    size?: Size;
 }
 
-export interface SliderRangeProps extends React.HTMLAttributes<HTMLInputElement> {
-    className?: string;
+export interface SliderRangeProps extends React.ComponentProps<'input'> {
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }

--- a/packages/ui/src/components/Slider/index.ts
+++ b/packages/ui/src/components/Slider/index.ts
@@ -1,4 +1,3 @@
-
 import {
     Slider as SliderComponent,
     SliderTrack,
@@ -13,14 +12,11 @@ import type {
     SliderThumbProps
  } from './Slider.types'; 
 
-
-
 const Slider = Object.assign(SliderComponent, {
     Track: SliderTrack,
     Range: SliderRange,
     Thumb: SliderThumb,
 });
-
 
 export { Slider };
 

--- a/packages/ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui/src/components/Switch/Switch.stories.tsx
@@ -5,25 +5,108 @@ const meta: Meta<typeof Switch> = {
     title: 'Components/Switch',
     component: Switch,
     tags: ['autodocs'],
+    argTypes: {
+        label: { control: 'text' },
+        disabled: { control: 'boolean' },
+        defaultChecked: { control: 'boolean' },
+        onChange: { action: 'changed' },
+        size: {
+            control: 'select',
+            options: ['small', 'medium', 'large'],
+        },
+        color: {
+            control: 'select',
+            options: ['primary', 'secondary'],
+        },
+    }
 }
 
 export default meta;
 type Story = StoryObj<typeof Switch>;
 
 export const Default: Story = {
-    render: (args) => (
-        <Switch {...args} label="레이블 문구가 들어갑니다."></Switch>
-    ),
-}
+    args: {
+        label: "레이블 문구가 들어갑니다.",
+        disabled: false,
+        defaultChecked: false,
+        size: 'medium',
+        color: 'primary',
+    },
+};
 
-export const OnlyInput: Story = {
-    render: (args) => (
-        <Switch {...args} defaultChecked ></Switch>
-    ),
-}
+export const States: Story = {
+    render: () => (
+        <>
+            <div>기본 상태:</div>
+            <Switch label="기본 스위치" />
+            
+            <div className="mt-4">체크된 상태:</div>
+            <Switch label="체크된 스위치" defaultChecked />
+            
+            <div className="mt-4">비활성화 상태:</div>
+            <Switch label="비활성화된 스위치" disabled />
+            
+            <div className="mt-4">체크되고 비활성화된 상태:</div>
+            <Switch label="체크되고 비활성화된 스위치" disabled defaultChecked />
+        </>
+    )
+};
 
-export const Disabled: Story = {
-    render: (args) => (
-        <Switch {...args} disabled></Switch>
-    ),
-}
+export const LabelOptions: Story = {
+    render: () => (
+        <>
+            <div>레이블 있음:</div>
+            <Switch label="레이블이 있는 스위치" />
+            
+            <div className="mt-4">레이블 없음:</div>
+            <Switch />
+        </>
+    )
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <>
+            <div>Small:</div>
+            <Switch 
+                label="작은 크기 스위치" 
+                size="small" 
+                color="primary"
+            />
+            
+            <div className="mt-4">Medium:</div>
+            <Switch 
+                label="중간 크기 스위치" 
+                size="medium" 
+                color="primary"
+            />
+            
+            <div className="mt-4">Large:</div>
+            <Switch 
+                label="큰 크기 스위치" 
+                size="large" 
+                color="primary"
+            />
+        </>
+    )
+};
+
+export const Colors: Story = {
+    render: () => (
+        <>
+            <div>Primary:</div>
+            <Switch 
+                label="기본 색상 스위치" 
+                color="primary" 
+                size="medium"
+            />
+            
+            <div className="mt-4">Secondary:</div>
+            <Switch 
+                label="보조 색상 스위치" 
+                color="secondary" 
+                size="medium"
+            />
+        </>
+    )
+};

--- a/packages/ui/src/components/Switch/Switch.tsx
+++ b/packages/ui/src/components/Switch/Switch.tsx
@@ -1,10 +1,8 @@
-import * as React from "react";
 import { useState } from "react";
 import { cn } from "../../utils/classname";
 import type { SwitchProps } from "./Switch.types";
 
-const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
-({
+const Switch = ({
     size = 'small',
     color = 'primary',
     label,
@@ -13,8 +11,9 @@ const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
     onChange,
     checked,
     className,
+    ref,
     ...props
-}, ref) => {
+}: SwitchProps) => {
 
     const [switchChecked, setSwitchChecked] = useState(defaultChecked);
 
@@ -57,10 +56,7 @@ const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
 
     return(
         <label
-            ref={ref}
-            className={cn(
-                switchLabelStyle,
-            )}
+            className={cn(switchLabelStyle, className)}
         >
             <input 
                 onChange={switchHandle}
@@ -68,6 +64,7 @@ const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
                 type="checkbox"
                 checked={currentChecked}
                 disabled={disabled}
+                ref={ref}
                 className={cn(
                     switchInputWrap,
                     switchInputSize,
@@ -86,7 +83,8 @@ const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
             
         </label>
     )
-})
+};
 
 Switch.displayName = "Switch";
+
 export { Switch };

--- a/packages/ui/src/components/Switch/Switch.types.ts
+++ b/packages/ui/src/components/Switch/Switch.types.ts
@@ -1,10 +1,10 @@
-export interface SwitchProps {
-    size?: 'small' | 'medium' | 'large';
-    color?: 'primary' | 'secondary';
+import type { Size, Color } from '../types';
+
+type SwitchColor = Exclude<Color, 'destructive'>;
+
+export interface SwitchProps extends Omit<React.ComponentProps<'input'>, 'size' | 'color' | 'onChange'> {
+    size?: Size;
+    color?: SwitchColor;
     label?: string;
-    disabled?: boolean;
-    defaultChecked?: boolean;
     onChange?: (checked: boolean) => void;
-    checked?: boolean;
-    className?: string;
 }

--- a/packages/ui/src/components/Tab/Tab.stories.tsx
+++ b/packages/ui/src/components/Tab/Tab.stories.tsx
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof Tab>;
 
 export const Primary: Story = {
     render: () => (
-        <Tab >
+        <Tab>
             <Tab.List color='primary'>
                 <Tab.Trigger value="tab1">첫번째 탭</Tab.Trigger>
                 <Tab.Trigger value="tab2">두번째 탭</Tab.Trigger>

--- a/packages/ui/src/components/Tab/Tab.types.ts
+++ b/packages/ui/src/components/Tab/Tab.types.ts
@@ -1,35 +1,30 @@
-import { HTMLAttributes } from 'react';
+import type { Color } from '../types';
 
 export interface TabContextProps {
     currentValue?: string;
     setCurrentValue: (value: string) => void;
     baseId: string;
-    color?: "primary" | "secondary";
+    color?: Color;
 }
 
-export interface TabProps extends HTMLAttributes<HTMLDivElement>{
+export interface TabProps extends React.ComponentProps<'div'>{
     defaultValue?: string;
     value?: string;
     onValueChange?: (value: string) => void;
-    className?: string;
-    ref?: React.RefObject<HTMLDivElement>;
-    color?: "primary" | "secondary";
+    color?: Color;
 }
 
-export interface TabListProps extends HTMLAttributes<HTMLDivElement>{
-    color?: "primary" | "secondary";
-    className?: string;
+export interface TabListProps extends React.ComponentProps<'div'>{
+    color?: Color;
 }
 
-export interface TabTriggerProps extends HTMLAttributes<HTMLButtonElement>{
+export interface TabTriggerProps extends React.ComponentProps<'button'>{
     isActive?: boolean;
     value: string;
-    className?: string;
-    color?: "primary" | "secondary";
+    color?: Color;
 }
 
-export interface TabContentProps extends HTMLAttributes<HTMLDivElement> {
+export interface TabContentProps extends React.ComponentProps<'div'>{
     isActive?: boolean;
     value: string;
-    className?: string;
 } 

--- a/packages/ui/src/components/Tab/index.ts
+++ b/packages/ui/src/components/Tab/index.ts
@@ -19,7 +19,6 @@ const Tab = Object.assign(TabComponent, {
     Content: TabContent
 });
 
-
 export { Tab };
 
 export type{

--- a/packages/ui/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.stories.tsx
@@ -4,9 +4,17 @@ import { Textarea } from './Textarea';
 const meta: Meta<typeof Textarea> = {
     title: 'Components/Textarea',
     tags: ['autodocs'],
-    args: {
-        placeholder: '텍스트를 입력하세요.',
-        resize: 'none',
+    argTypes:{
+        placeholder: {
+            control: 'text',
+        },
+        resize: {
+            control: 'select',
+            options: ['both', 'horizontal', 'resize-y', 'none']
+        },
+        className: {
+            control: 'text',
+        },
     }
 }
 
@@ -36,10 +44,17 @@ export const TextareaDisabled: StoryObj<typeof Textarea> = {
 }
 
 export const TextareaResize: StoryObj<typeof Textarea> = {
-    render: (args) => <Textarea {...args} />,
-    args: {
-        placeholder: '사이즈를 조절할 수 있습니다.',
-        resize: 'both'
-    }
+    render: () => (
+        <>
+            <div className="mt-4">Resize: none</div>
+            <Textarea placeholder="사이즈를 조절할 수 있습니다." />
+            <div className="mt-4">Resize: horizontal</div>
+            <Textarea resize="horizontal" placeholder="사이즈를 조절할 수 있습니다."/>
+            <div className="mt-4">Resize: vertical</div>
+            <Textarea resize="vertical" placeholder="사이즈를 조절할 수 있습니다."/>
+            <div className="mt-4">Resize: both</div>
+            <Textarea resize="both" placeholder="사이즈를 조절할 수 있습니다."/>
+        </>
+    ),
 }
 

--- a/packages/ui/src/components/Textarea/Textarea.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.tsx
@@ -1,22 +1,17 @@
 import * as React from "react";
 import { cn } from "../../utils/classname";
+import type { TextareaProps } from "./Textarea.types";
 
-export interface TextareaProps extends React.ComponentProps<'textarea'> {
-    ariaLabel?: string;
-    resize?: "none" | "both" | "horizontal" | "vertical";
-    invalid?: boolean;
-    onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-    className?: string;
-}
-
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
+const Textarea = ({
     ariaLabel,
     resize = "none",
     invalid = false,
     value,
     onChange,
     className, 
-    ...props }, ref) => {
+    ref,
+    ...props 
+  }: TextareaProps ) => {
       
     const textareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange?.(e);
@@ -45,9 +40,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
         {...props}
       />
     </>
-  )
-})
+  )};
 
 Textarea.displayName = 'Textarea';
 
-export { Textarea }
+export { Textarea };

--- a/packages/ui/src/components/Textarea/Textarea.types.ts
+++ b/packages/ui/src/components/Textarea/Textarea.types.ts
@@ -1,0 +1,6 @@
+export interface TextareaProps extends React.ComponentProps<'textarea'> {
+    ariaLabel?: string;
+    resize?: "none" | "both" | "horizontal" | "vertical";
+    invalid?: boolean;
+    onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}

--- a/packages/ui/src/components/Textarea/index.ts
+++ b/packages/ui/src/components/Textarea/index.ts
@@ -1,2 +1,2 @@
 export {Textarea} from './Textarea';
-export type { TextareaProps } from './Textarea';
+export type { TextareaProps } from './Textarea.types';

--- a/packages/ui/src/components/Time/Time.stories.tsx
+++ b/packages/ui/src/components/Time/Time.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Time from './Time';
+import { Time } from './Time';
 
 const meta: Meta<typeof Time> = {
   title: 'Components/Time',
   component: Time,
   tags: ['autodocs'],
   argTypes: {
-    variant: {
+    color: {
       control: 'select',
-      options: ['black', 'white'],
+      options: ['primary', 'secondary'],
     },
     size: {
       control: 'select',
@@ -17,7 +17,7 @@ const meta: Meta<typeof Time> = {
     format:{
       control: 'select',
       options:['HH:mm:ss', 'HH:mm', 'YYYY-MM-DD', 'locale']
-    }
+    },
   },
 };
 
@@ -27,10 +27,54 @@ type Story = StoryObj<typeof Time>;
 
 export const Primary: Story = {
   args: {
-    variant: 'black',
+    color: 'primary',
     size:'small',
     format : 'YYYY-MM-DD HH:mm:ss',
   },
+};
+
+export const Colors: Story = {
+  render: () => (
+    <>
+      <div>Primary:</div>
+      <Time 
+        color="primary" 
+        size="small" 
+        format="YYYY-MM-DD HH:mm:ss"
+      />
+      <div className="mt-4">Secondary:</div>
+      <Time 
+        color="secondary" 
+        size="small" 
+        format="YYYY-MM-DD HH:mm:ss"
+      />
+    </>
+  )
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <div>Small:</div>
+      <Time 
+        color="primary" 
+        size="small" 
+        format="YYYY-MM-DD HH:mm:ss"
+      />
+      <div className="mt-4">Medium:</div>
+      <Time 
+        color="primary" 
+        size="medium" 
+        format="YYYY-MM-DD HH:mm:ss"
+      />
+      <div className="mt-4">Large:</div>
+      <Time 
+        color="primary" 
+        size="large" 
+        format="YYYY-MM-DD HH:mm:ss"
+      />
+    </>
+  )
 };
 
 

--- a/packages/ui/src/components/Time/Time.tsx
+++ b/packages/ui/src/components/Time/Time.tsx
@@ -1,17 +1,10 @@
-import { TimeHTMLAttributes, useEffect, useState } from 'react';
-import clsx from 'clsx';
-
-export interface TimeProps extends TimeHTMLAttributes<HTMLTimeElement> {
-  variant?: 'black' | 'white';
-  size?: 'small' | 'medium' | 'large';
-  lang?: string;
-  format? :string;
-  className?: string;
-}
+import { useEffect, useState } from 'react';
+import { cn } from '../../utils/classname';
+import type { TimeProps } from './Time.types';
 
 const Time = ({ 
-  variant = 'black',
-  lang = 'ko',
+  color = 'primary',
+  lang = 'ko-KR',
   size = 'small',
   format = 'YYYY-MM-DD HH:mm:ss',
   className,
@@ -21,9 +14,9 @@ const Time = ({
   const timeStyle = 'flex gap-2 items-center font-bold';
 
   const variantStyle = {
-    black: 'text-black',
-    white: 'text-white'
-  }[variant];
+    primary: 'text-black',
+    secondary: 'text-white'
+  }[color];
 
   const sizeStyle = {
     small: 'text-sm',
@@ -81,7 +74,7 @@ useEffect(() => {
   
   return (
     <time 
-        className={clsx(
+        className={cn(
             variantStyle,
             timeStyle,
             sizeStyle,
@@ -94,5 +87,7 @@ useEffect(() => {
   );
 };
 
-export default Time;
+Time.displayName = "Time";
+
+export { Time };
 

--- a/packages/ui/src/components/Time/Time.types.ts
+++ b/packages/ui/src/components/Time/Time.types.ts
@@ -1,0 +1,10 @@
+import type { Color, Size } from '../types';
+
+type TimeColor = Exclude<Color, 'destructive'>;
+
+export interface TimeProps extends React.ComponentProps<'time'> {
+    color?: TimeColor;
+    size?: Size;
+    lang?: string;
+    format? :string;
+}

--- a/packages/ui/src/components/Time/index.ts
+++ b/packages/ui/src/components/Time/index.ts
@@ -1,2 +1,2 @@
-export { default as Time } from "./Time"
-export type { TimeProps } from "./Time"
+export { Time } from "./Time"
+export type { TimeProps } from "./Time.types"

--- a/packages/ui/src/components/types.ts
+++ b/packages/ui/src/components/types.ts
@@ -1,0 +1,2 @@
+export type Size = 'small' | 'medium' | 'large';
+export type Color = 'primary' | 'secondary' | 'destructive';


### PR DESCRIPTION
## 요약
  디자인 시스템 리팩토링 진행   

## 이슈 넘버 or 관련 링크
  #67 Design-System 중간 리팩토링

## 변경사항 🏗️  

<!-- 변경 사항에 대해서 기재 필요 -->
### Checklist 📋
## 코드 변경 사항   
- [x] UUID 사용되는 부분은 리액트의 userID 로 수정 
- [x] useRef 를 따로 Wrapping 하지 않고 ref 를 Props 로 전달
- [x] React.memo 필요한 컴포넌트에 적용 
- [x] 공통으로 Size, Color 타입 생성 -> 상이한 컴포넌트에 대해서는 Size, Color 를 Omit 하여 재정의
- [x] `HTMLDivElement` 대신 `React.ComponentProps<'tag'>`로 변경하여 모든 HTML 태그에 대해 React props를 자동으로 처리할 수 있도록 개선
