### PR TITLE
사용자 권한에 CCTV 추가

### DIFF
--- a/apps/core/src/app/view/components/maps/DeviceCategoryChips.tsx
+++ b/apps/core/src/app/view/components/maps/DeviceCategoryChips.tsx
@@ -60,11 +60,6 @@ const DeviceCategoryChips = ({
       thumbnailFile: {
         id: -1,
         url: '/images/icons/cctv.png',
-        originalFileName: 'cctv.png',
-        contentType: 'image/png',
-        fileStatus: 'uploaded' as const,
-        createdAt: new Date().toISOString(),
-        createdBy: 'System',
       },
     };
     

--- a/apps/core/src/app/view/components/maps/IndoorMap.tsx
+++ b/apps/core/src/app/view/components/maps/IndoorMap.tsx
@@ -1,32 +1,36 @@
+import { useEffect, useCallback, useState, useRef } from 'react'
+
+import type { DeviceResponse, FacilityType } from '@plug/common-services'
 import { Poi } from '@plug/engine'
 
+import { MapScene } from '@/global/components/indoor-map'
 import { useAssets } from '@/global/store/assetStore'
-
-import type { IndoorSearchItem } from '@/app/store/indoorStore'
-
 import { getDeviceLatestNormalized } from '@/global/services'
 
 import { DeviceInfoDialog } from '../dialogs'
 
-import React, { useEffect, useCallback, useState, useRef } from 'react'
-
-import type { DeviceResponse, FacilityType } from '@plug/common-services'
-
 import { useFacilityStore } from '@/app/store/facilityStore'
 import { useIndoorStore } from '@/app/store/indoorStore'
+import type { IndoorSearchItem } from '@/app/store/indoorStore'
+
 import { useIndoorEngine, useIndoorFacilityData, usePoiEmbeddedWebRTC } from '@/app/view/hooks'
-import { MapScene } from '@/global/components/indoor-map'
 
 import DeviceCategoryChips from './DeviceCategoryChips'
 import IndoorSearchForm from './IndoorSearchForm'
-interface IndoorMapProps { facilityId: number; facilityType: FacilityType; onGoOutdoor?: () => void }
 
-const IndoorMap: React.FC<IndoorMapProps> = ({ facilityId, facilityType, onGoOutdoor }) => {
+interface IndoorMapProps { 
+  facilityId: number; 
+  facilityType: FacilityType; 
+  onGoOutdoor?: () => void 
+}
+
+const IndoorMap = ({ facilityId, facilityType, onGoOutdoor }: IndoorMapProps) => {
   const facilitiesFetched = useFacilityStore(s => s.facilitiesFetched)
   const { assets } = useAssets()
   const { features, floors, has3DDrawing, isLoading, countdown, modelUrl, handleOutdoor } = useIndoorFacilityData({ facilityId, facilityType, onGoOutdoor })
   const loadCctvs = useIndoorStore(s => s.loadCctvs)
   const loadDevices = useIndoorStore(s => s.loadDevices)
+  
   useEffect(() => {
     if (facilityId) {
       loadDevices(facilityId)

--- a/apps/core/src/backoffice/domains/users/components/PermissionEditModal.tsx
+++ b/apps/core/src/backoffice/domains/users/components/PermissionEditModal.tsx
@@ -1,17 +1,16 @@
-import { toast } from 'sonner';
-
-import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
 
 import { usePermissionDetail, useUpdatePermission } from '@plug/common-services';
 import { Dialog, DialogContent, DialogFooter, ModalForm, ModalFormContainer, ModalFormField, ModalFormItem, Input, Button, Checkbox, Label } from '@plug/ui';
 
 import { usePermissionCheckbox } from '@/backoffice/domains/users/hooks/usePermissionCheckbox';
-import { permissionFormSchema, type PermissionFormData } from '@/backoffice/domains/users/schemas/permissionSchemas';
 import { usePermissionStore } from '@/backoffice/domains/users/stores/permissionStore';
 import { PermissionEditModalProps } from '@/backoffice/domains/users/types/permisson';
-export const PermissionEditModal : React.FC<PermissionEditModalProps> = ({ isOpen, onClose, onSuccess, permissionId }) => {
+import { permissionFormSchema, type PermissionFormData } from '@/backoffice/domains/users/schemas/permissionSchemas';
+export const PermissionEditModal = ({ isOpen, onClose, onSuccess, permissionId }: PermissionEditModalProps) => {
     const { data: detailData, execute: detailPermission } = usePermissionDetail(permissionId);
     const { execute: updatePermission, isLoading: isPermissionUpdating } = useUpdatePermission(permissionId);
     const { resourceTypes, resourceData, isLoading: isResourceDataLoading, error: resourceError } = usePermissionStore();
@@ -114,7 +113,6 @@ export const PermissionEditModal : React.FC<PermissionEditModalProps> = ({ isOpe
                                                             <div className="font-semibold">{resourceType.name}</div>
                                                             <div className="flex flex-wrap gap-x-6 gap-y-2">
                                                                 {resourceType.key === 'CCTV' ? (
-                                                                    // CCTV는 전체 선택/해제만 제공
                                                                     <div className="flex items-center gap-2">
                                                                         <Checkbox 
                                                                             variant="square" 
@@ -131,7 +129,6 @@ export const PermissionEditModal : React.FC<PermissionEditModalProps> = ({ isOpe
                                                                         <Label htmlFor="cctv-all">CCTV</Label>
                                                                     </div>
                                                                 ) : (
-                                                                    // 다른 리소스 타입은 기존처럼 개별 선택
                                                                     resources.length > 0 ? (
                                                                         resources.map((resource) => {
                                                                             const checkboxId = `${resourceType.key}-${resource.id}`;

--- a/apps/core/src/backoffice/domains/users/components/PermissionEditModal.tsx
+++ b/apps/core/src/backoffice/domains/users/components/PermissionEditModal.tsx
@@ -15,7 +15,7 @@ export const PermissionEditModal : React.FC<PermissionEditModalProps> = ({ isOpe
     const { data: detailData, execute: detailPermission } = usePermissionDetail(permissionId);
     const { execute: updatePermission, isLoading: isPermissionUpdating } = useUpdatePermission(permissionId);
     const { resourceTypes, resourceData, isLoading: isResourceDataLoading, error: resourceError } = usePermissionStore();
-    const { isResourceSelected, handleCheckboxChange } = usePermissionCheckbox();
+    const { isResourceSelected, handleCheckboxChange, isCCTVAllSelected, handleCCTVAllToggle } = usePermissionCheckbox();
 
     const modalForm = useForm<PermissionFormData>({
         resolver: zodResolver(permissionFormSchema),
@@ -113,31 +113,51 @@ export const PermissionEditModal : React.FC<PermissionEditModalProps> = ({ isOpe
                                                         <div key={resourceType.key} className="flex flex-col gap-2">
                                                             <div className="font-semibold">{resourceType.name}</div>
                                                             <div className="flex flex-wrap gap-x-6 gap-y-2">
-                                                                {resources.length > 0 ? (
-                                                                    resources.map((resource) => {
-                                                                        const checkboxId = `${resourceType.key}-${resource.id}`;
-                                                                        return (
-                                                                            <div key={resource.id} className="flex items-center gap-2">
-                                                                                <Checkbox 
-                                                                                    variant="square" 
-                                                                                    id={checkboxId}
-                                                                                    checked={isResourceSelected(field.value || [], resourceType.key, resource.id)}
-                                                                                    onCheckedChange={(checked) => 
-                                                                                        handleCheckboxChange(
-                                                                                            field.value || [], 
-                                                                                            field.onChange, 
-                                                                                            resourceType.key, 
-                                                                                            resource.id, 
-                                                                                            !!checked
-                                                                                        )
-                                                                                    }
-                                                                                />
-                                                                                <Label htmlFor={checkboxId}>{resource.name}</Label>
-                                                                            </div>
-                                                                        );
-                                                                    })
+                                                                {resourceType.key === 'CCTV' ? (
+                                                                    // CCTV는 전체 선택/해제만 제공
+                                                                    <div className="flex items-center gap-2">
+                                                                        <Checkbox 
+                                                                            variant="square" 
+                                                                            id="cctv-all"
+                                                                            checked={isCCTVAllSelected(field.value || [])}
+                                                                            onCheckedChange={(checked) => 
+                                                                                handleCCTVAllToggle(
+                                                                                    field.value || [], 
+                                                                                    field.onChange, 
+                                                                                    !!checked
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                        <Label htmlFor="cctv-all">CCTV</Label>
+                                                                    </div>
                                                                 ) : (
-                                                                    <div className="text-gray-500 text-sm">사용 가능한 리소스가 없습니다.</div>
+                                                                    // 다른 리소스 타입은 기존처럼 개별 선택
+                                                                    resources.length > 0 ? (
+                                                                        resources.map((resource) => {
+                                                                            const checkboxId = `${resourceType.key}-${resource.id}`;
+                                                                            return (
+                                                                                <div key={resource.id} className="flex items-center gap-2">
+                                                                                    <Checkbox 
+                                                                                        variant="square" 
+                                                                                        id={checkboxId}
+                                                                                        checked={isResourceSelected(field.value || [], resourceType.key, resource.id)}
+                                                                                        onCheckedChange={(checked) => 
+                                                                                            handleCheckboxChange(
+                                                                                                field.value || [], 
+                                                                                                field.onChange, 
+                                                                                                resourceType.key, 
+                                                                                                resource.id, 
+                                                                                                !!checked
+                                                                                            )
+                                                                                        }
+                                                                                    />
+                                                                                    <Label htmlFor={checkboxId}>{resource.name}</Label>
+                                                                                </div>
+                                                                            );
+                                                                        })
+                                                                    ) : (
+                                                                        <div className="text-gray-500 text-sm">사용 가능한 리소스가 없습니다.</div>
+                                                                    )
                                                                 )}
                                                             </div>
                                                         </div>

--- a/apps/core/src/backoffice/domains/users/components/PermisstionCreateModal.tsx
+++ b/apps/core/src/backoffice/domains/users/components/PermisstionCreateModal.tsx
@@ -1,9 +1,7 @@
-import { permissionFormSchema, type PermissionFormData } from '@/backoffice/domains/users/schemas/permissionSchemas';  
-import { toast } from 'sonner';
-
-import { zodResolver } from '@hookform/resolvers/zod';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
 
 import { useCreatePermission } from '@plug/common-services/services';
 import { Dialog, DialogContent, DialogFooter, Button, ModalForm, ModalFormContainer, ModalFormField, ModalFormItem, Input, Checkbox, Label } from '@plug/ui';
@@ -11,7 +9,8 @@ import { Dialog, DialogContent, DialogFooter, Button, ModalForm, ModalFormContai
 import { usePermissionCheckbox } from '@/backoffice/domains/users/hooks/usePermissionCheckbox';
 import { usePermissionStore } from '@/backoffice/domains/users/stores/permissionStore';
 import { PermissionCreateModalProps } from '@/backoffice/domains/users/types/permisson';
-export const PermissionCreateModal: React.FC<PermissionCreateModalProps> = ({ isOpen, onClose, onSuccess }) => {
+import { permissionFormSchema, type PermissionFormData } from '@/backoffice/domains/users/schemas/permissionSchemas';
+export const PermissionCreateModal = ({ isOpen, onClose, onSuccess }: PermissionCreateModalProps) => {
     const { execute: createPermission, isLoading: isPermissionCreating } = useCreatePermission();
     const { resourceTypes, resourceData, isLoading: isResourceDataLoading, error: resourceError } = usePermissionStore();
     const { isResourceSelected, handleCheckboxChange, isCCTVAllSelected, handleCCTVAllToggle } = usePermissionCheckbox();
@@ -95,7 +94,6 @@ export const PermissionCreateModal: React.FC<PermissionCreateModalProps> = ({ is
                                                             <div className="font-semibold">{resourceType.name}</div>
                                                             <div className="flex flex-wrap gap-x-6 gap-y-2">
                                                                 {resourceType.key === 'CCTV' ? (
-                                                                    // CCTV는 전체 선택/해제만 제공
                                                                     <div className="flex items-center gap-2">
                                                                         <Checkbox 
                                                                             variant="square" 
@@ -112,7 +110,6 @@ export const PermissionCreateModal: React.FC<PermissionCreateModalProps> = ({ is
                                                                         <Label htmlFor="cctv-all">CCTV</Label>
                                                                     </div>
                                                                 ) : (
-                                                                    // 다른 리소스 타입은 기존처럼 개별 선택
                                                                     resources.length > 0 ? (
                                                                         resources.map((resource) => {
                                                                             const checkboxId = `${resourceType.key}-${resource.id}`;

--- a/apps/core/src/backoffice/domains/users/components/PermisstionCreateModal.tsx
+++ b/apps/core/src/backoffice/domains/users/components/PermisstionCreateModal.tsx
@@ -14,7 +14,7 @@ import { PermissionCreateModalProps } from '@/backoffice/domains/users/types/per
 export const PermissionCreateModal: React.FC<PermissionCreateModalProps> = ({ isOpen, onClose, onSuccess }) => {
     const { execute: createPermission, isLoading: isPermissionCreating } = useCreatePermission();
     const { resourceTypes, resourceData, isLoading: isResourceDataLoading, error: resourceError } = usePermissionStore();
-    const { isResourceSelected, handleCheckboxChange } = usePermissionCheckbox();
+    const { isResourceSelected, handleCheckboxChange, isCCTVAllSelected, handleCCTVAllToggle } = usePermissionCheckbox();
 
     const modalForm = useForm<PermissionFormData>({
         resolver: zodResolver(permissionFormSchema),
@@ -94,31 +94,51 @@ export const PermissionCreateModal: React.FC<PermissionCreateModalProps> = ({ is
                                                         <div key={resourceType.key} className="flex flex-col gap-2">
                                                             <div className="font-semibold">{resourceType.name}</div>
                                                             <div className="flex flex-wrap gap-x-6 gap-y-2">
-                                                                {resources.length > 0 ? (
-                                                                    resources.map((resource) => {
-                                                                        const checkboxId = `${resourceType.key}-${resource.id}`;
-                                                                        return (
-                                                                            <div key={resource.id} className="flex items-center gap-2">
-                                                                                <Checkbox 
-                                                                                    variant="square" 
-                                                                                    id={checkboxId}
-                                                                                    checked={isResourceSelected(field.value || [], resourceType.key, resource.id)}
-                                                                                    onCheckedChange={(checked) => 
-                                                                                        handleCheckboxChange(
-                                                                                            field.value || [], 
-                                                                                            field.onChange, 
-                                                                                            resourceType.key, 
-                                                                                            resource.id, 
-                                                                                            !!checked
-                                                                                        )
-                                                                                    }
-                                                                                />
-                                                                                <Label htmlFor={checkboxId}>{resource.name}</Label>
-                                                                            </div>
-                                                                        );
-                                                                    })
+                                                                {resourceType.key === 'CCTV' ? (
+                                                                    // CCTV는 전체 선택/해제만 제공
+                                                                    <div className="flex items-center gap-2">
+                                                                        <Checkbox 
+                                                                            variant="square" 
+                                                                            id="cctv-all"
+                                                                            checked={isCCTVAllSelected(field.value || [])}
+                                                                            onCheckedChange={(checked) => 
+                                                                                handleCCTVAllToggle(
+                                                                                    field.value || [], 
+                                                                                    field.onChange, 
+                                                                                    !!checked
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                        <Label htmlFor="cctv-all">CCTV</Label>
+                                                                    </div>
                                                                 ) : (
-                                                                    <div className="text-gray-500 text-sm">사용 가능한 리소스가 없습니다.</div>
+                                                                    // 다른 리소스 타입은 기존처럼 개별 선택
+                                                                    resources.length > 0 ? (
+                                                                        resources.map((resource) => {
+                                                                            const checkboxId = `${resourceType.key}-${resource.id}`;
+                                                                            return (
+                                                                                <div key={resource.id} className="flex items-center gap-2">
+                                                                                    <Checkbox 
+                                                                                        variant="square" 
+                                                                                        id={checkboxId}
+                                                                                        checked={isResourceSelected(field.value || [], resourceType.key, resource.id)}
+                                                                                        onCheckedChange={(checked) => 
+                                                                                            handleCheckboxChange(
+                                                                                                field.value || [], 
+                                                                                                field.onChange, 
+                                                                                                resourceType.key, 
+                                                                                                resource.id, 
+                                                                                                !!checked
+                                                                                            )
+                                                                                        }
+                                                                                    />
+                                                                                    <Label htmlFor={checkboxId}>{resource.name}</Label>
+                                                                                </div>
+                                                                            );
+                                                                        })
+                                                                    ) : (
+                                                                        <div className="text-gray-500 text-sm">사용 가능한 리소스가 없습니다.</div>
+                                                                    )
                                                                 )}
                                                             </div>
                                                         </div>

--- a/apps/core/src/backoffice/domains/users/hooks/usePermissionCheckbox.ts
+++ b/apps/core/src/backoffice/domains/users/hooks/usePermissionCheckbox.ts
@@ -13,6 +13,14 @@ export const usePermissionCheckbox = () => {
         );
     }, []);
 
+    // CCTV 전체 권한 체크 함수
+    const isCCTVAllSelected = useCallback((permissions: PermissionItem[]) => {
+        return permissions.some(permission => 
+            permission.resourceType === 'CCTV' && 
+            permission.resourceIds.includes('ALL')
+        );
+    }, []);
+
     const handleCheckboxChange = useCallback((
         permissions: PermissionItem[], 
         onChange: (value: PermissionItem[]) => void, 
@@ -47,8 +55,39 @@ export const usePermissionCheckbox = () => {
         onChange(newPermissions);
     }, []);
 
+    // CCTV 전체 권한 토글 함수
+    const handleCCTVAllToggle = useCallback((
+        permissions: PermissionItem[],
+        onChange: (value: PermissionItem[]) => void,
+        checked: boolean
+    ) => {
+        const newPermissions = [...permissions];
+        const existingPermissionIndex = newPermissions.findIndex(p => p.resourceType === 'CCTV');
+        
+        if (checked) {
+            if (existingPermissionIndex >= 0) {
+                newPermissions[existingPermissionIndex] = {
+                    resourceType: 'CCTV',
+                    resourceIds: ['ALL']
+                };
+            } else {
+                newPermissions.push({
+                    resourceType: 'CCTV',
+                    resourceIds: ['ALL']
+                });
+            }
+        } else {
+            if (existingPermissionIndex >= 0) {
+                newPermissions.splice(existingPermissionIndex, 1);
+            }
+        }
+        onChange(newPermissions);
+    }, []);
+
     return {
         isResourceSelected,
-        handleCheckboxChange
+        handleCheckboxChange,
+        isCCTVAllSelected,
+        handleCCTVAllToggle
     };
 }; 

--- a/apps/core/src/global/store/authStore.ts
+++ b/apps/core/src/global/store/authStore.ts
@@ -1,7 +1,7 @@
-import { UserProfile } from '@plug/common-services/types';
-
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+
+import { UserProfile } from '@plug/common-services/types';
 interface AuthStore {
   user: UserProfile | null;
   isAuthenticated: boolean;
@@ -17,6 +17,8 @@ interface AuthStore {
   hasRole: (roleName: string) => boolean;
   // 간단한 사용자 정보 업데이트 (로컬 상태만)
   updateLocalUserInfo: (updates: Partial<UserProfile>) => void;
+  // 권한 정보 조회
+  getUserPermissions: () => Array<{ resourceType: string; resourceIds: string[] }>;
 }
 
 export const useAuthStore = create<AuthStore>()(
@@ -43,6 +45,21 @@ export const useAuthStore = create<AuthStore>()(
         if (currentUser) {
           set({ user: { ...currentUser, ...updates } });
         }
+      },
+      // 사용자의 모든 권한 정보를 평면화해서 반환
+      getUserPermissions: () => {
+        const user = get().user;
+        if (!user?.roles) return [];
+        
+        const allPermissions: Array<{ resourceType: string; resourceIds: string[] }> = [];
+        
+        for (const role of user.roles) {
+          for (const permission of role.permissions) {
+            allPermissions.push(...permission.permissions);
+          }
+        }
+        
+        return allPermissions;
       },
     }),
     {

--- a/apps/core/src/global/store/authStore.ts
+++ b/apps/core/src/global/store/authStore.ts
@@ -15,10 +15,9 @@ interface AuthStore {
   getUsername: () => string | undefined;
   getUserRoles: () => string[];
   hasRole: (roleName: string) => boolean;
-  // 간단한 사용자 정보 업데이트 (로컬 상태만)
   updateLocalUserInfo: (updates: Partial<UserProfile>) => void;
-  // 권한 정보 조회
   getUserPermissions: () => Array<{ resourceType: string; resourceIds: string[] }>;
+  hasPermission: (resourceType: string, resourceId?: string) => boolean;
 }
 
 export const useAuthStore = create<AuthStore>()(
@@ -39,27 +38,53 @@ export const useAuthStore = create<AuthStore>()(
         const roles = get().getUserRoles();
         return roles.includes(roleName);
       },
-      // 로컬 상태 업데이트 (서버 동기화는 별도 처리)
       updateLocalUserInfo: (updates: Partial<UserProfile>) => {
         const currentUser = get().user;
         if (currentUser) {
           set({ user: { ...currentUser, ...updates } });
         }
       },
-      // 사용자의 모든 권한 정보를 평면화해서 반환
       getUserPermissions: () => {
         const user = get().user;
         if (!user?.roles) return [];
-        
-        const allPermissions: Array<{ resourceType: string; resourceIds: string[] }> = [];
-        
+
+        const merged = new Map<string, Set<string>>();
+
         for (const role of user.roles) {
           for (const permission of role.permissions) {
-            allPermissions.push(...permission.permissions);
+            for (const p of permission.permissions) {
+              if (!merged.has(p.resourceType)) {
+                merged.set(p.resourceType, new Set<string>());
+              }
+              const ids = merged.get(p.resourceType)!;
+
+              if (ids.has('ALL')) {
+                continue;
+              }
+
+              if (p.resourceIds.includes('ALL')) {
+                ids.clear();
+                ids.add('ALL');
+              } else {
+                for (const id of p.resourceIds) {
+                  ids.add(id);
+                }
+              }
+            }
           }
         }
-        
-        return allPermissions;
+
+        return Array.from(merged.entries()).map(([resourceType, resourceIds]) => ({
+          resourceType,
+          resourceIds: Array.from(resourceIds),
+        }));
+      },
+      hasPermission: (resourceType: string, resourceId?: string) => {
+        const permissions = get().getUserPermissions();
+        const permission = permissions.find(p => p.resourceType === resourceType);
+        if (!permission) return false;
+        if (!resourceId) return true;
+        return permission.resourceIds.includes('ALL') || permission.resourceIds.includes(resourceId);
       },
     }),
     {


### PR DESCRIPTION
## 요약

이 PR은 애플리케이션 전반에 걸쳐 CCTV 관련 기능에 대한 사용자 권한 제어를 구현합니다. 이를 통해 권한이 없는 사용자가 CCTV 데이터를 로드하거나, 검색 결과에서 보거나, UI에서 CCTV 카테고리를 볼 수 없도록 합니다. 또한, 백오피스에서 사용자 권한을 관리할 때 CCTV 권한을 보다 명확하고 쉽게 설정할 수 있도록 UI와 관련 로직을 개선했습니다.

## 변경사항 🏗️  

* **CCTV 권한 제어 강화**: indoorStore.ts 파일에서 CCTV 데이터 로드, 검색 및 조회 시 사용자 권한을 확인하는 로직이 추가되었습니다.
* **UI에 권한 반영**: DeviceCategoryChips.tsx 파일에서 CCTV 카테고리 칩 표시 여부가 사용자 CCTV 권한에 따라 동적으로 결정되도록 변경되었습니다. 또한, 일반 장치 카테고리도 DEVICE_CATEGORY 권한에 따라 필터링됩니다.
* **권한 관리 UI 개선**: 백오피스 사용자 권한 생성 및 수정 모달(PermissionEditModal.tsx, PermisstionCreateModal.tsx)에 CCTV 권한을 '전체'로 설정할 수 있는 전용 체크박스가 추가되었습니다.
* **권한 헬퍼 함수 추가**: usePermissionCheckbox.ts 훅에 CCTV 전체 권한 상태를 확인하고 토글하는 헬퍼 함수(isCCTVAllSelected, handleCCTVAllToggle)가 구현되었습니다.
* **사용자 권한 조회 기능**: authStore.ts에 사용자의 모든 권한을 평면화하여 반환하는 getUserPermissions 메서드가 추가되어 권한 확인 로직을 중앙 집중화했습니다.
